### PR TITLE
use prepare to enable install from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "gulp lint",
     "build": "gulp build",
     "clean": "gulp clean",
+    "prepare": "npm run build",
     "release": "gulp release:minor",
     "release:patch": "gulp release:patch",
     "release:minor": "gulp release:minor",


### PR DESCRIPTION
>**prepare**: Run both BEFORE the package is packed and published, on local npm install without any arguments, and when installing git dependencies (See below). This is run AFTER prepublish, but BEFORE prepublishOnly.

cc #341 